### PR TITLE
Fix branch of remote version file URL

### DIFF
--- a/resurfaced.version
+++ b/resurfaced.version
@@ -1,6 +1,6 @@
 {
 	"NAME": "Resurfaced",
-	"URL": "https://raw.githubusercontent.com/Tantares/Resurfaced/master/resurfaced.version",
+	"URL": "https://raw.githubusercontent.com/Tantares/Resurfaced/main/resurfaced.version",
 	"DOWNLOAD" : "https://github.com/Tantares/Resurfaced/releases",
 	"GITHUB": {
 		"USERNAME": "Tantares",


### PR DESCRIPTION
Hi @Tantares,

This repo uses a `main` branch, but the version file says `master`. GitHub will redirect this in its web UI, but not the API.

Now it's fixed.

Noticed while working on KSP-CKAN/NetKAN#10173.
